### PR TITLE
fix: correct site metadata description property

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,7 +8,7 @@
 module.exports = {
   siteMetadata: {
     title: 'BackRoads',
-    desription:
+    description:
       'Explore very cool Worldwide Tours & discover what make each of them unique. Forget your daily routine & and say yes! to adventure',
     author: '@bodhicougar',
     data: {

--- a/src/examples/Header.js
+++ b/src/examples/Header.js
@@ -3,10 +3,10 @@ import { useStaticQuery, graphql } from 'gatsby'
 
 const getSiteData = graphql`
   query SecondQuery {
-    site(siteMetadata: { author: {}, data: {}, desription: {} }) {
+    site(siteMetadata: { author: {}, data: {}, description: {} }) {
       siteMetadata {
         title
-        desription
+        description
         author
       }
     }

--- a/src/examples/RegularHeader.js
+++ b/src/examples/RegularHeader.js
@@ -3,10 +3,10 @@ import { StaticQuery, graphql } from 'gatsby'
 
 const getSiteData = graphql`
   query FirstQuery {
-    site(siteMetadata: { author: {}, data: {}, desription: {} }) {
+    site(siteMetadata: { author: {}, data: {}, description: {} }) {
       siteMetadata {
         title
-        desription
+        description
         author
       }
     }
@@ -17,7 +17,7 @@ const RegularHeader = () => {
   return (
     <StaticQuery
       query={getSiteData}
-      render={data => {
+      render={(data) => {
         return <h1>Hello people!</h1>
       }}
     />

--- a/src/pages/blog copy.js
+++ b/src/pages/blog copy.js
@@ -17,7 +17,7 @@ export const query = graphql`
     site {
       siteMetadata {
         title
-        desription
+        description
         author
         data {
           age


### PR DESCRIPTION
## Summary
- fix typo in site metadata `description` field
- update GraphQL queries to use `description`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a978ea78988331b66d9f9cdb3afa5e